### PR TITLE
py2/py3 compat depend list generation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,6 @@ import ast
 import os
 from setuptools import setup, find_packages
 
-
-local_file = lambda *f: \
-    open(os.path.join(os.path.dirname(__file__), *f), 'rb').read()
-
-
 class VersionFinder(ast.NodeVisitor):
     VARIABLE_NAME = 'version'
 
@@ -30,7 +25,7 @@ def read_version():
     return finder.version
 
 
-dependencies = filter(bool, map(bytes.strip, local_file('requirements.txt').splitlines()))
+dependencies = [x.split('==')[0] for x in open('requirements.txt').readlines()]
 
 setup(
     name='keybone',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def read_version():
     return finder.version
 
 
-dependencies = [x.split('==')[0] for x in open('requirements.txt').readlines()]
+dependencies = [x.split('==')[0] for x in open('requirements.txt', 'r')]
 
 setup(
     name='keybone',


### PR DESCRIPTION
map() returns iterable on py3, which was failing with error in keybone setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; 'int' object is not iterable
change to more generic readlines() method to work on both